### PR TITLE
feat: enhance fault tolerance

### DIFF
--- a/code.js
+++ b/code.js
@@ -201,7 +201,7 @@ $(function () {
           fromJsonLines.push(`${makeBlank(count * 3)}v.forEach((v) {\n${makeBlank(count * 4)}arr${count}.add(${className}.fromJson(v));\n${makeBlank(count * 3)}});`);
           toJsonLines.push(`${makeBlank(count * 3)}v.forEach((v) {\n${makeBlank(count * 4)}arr${count}.add(v.toJson());\n${makeBlank(count * 3)}});`);
         } else {
-          let toType = '';
+          let toType = 'v';
           if (typeof inner === 'boolean') {
             //we don't handle boolean
           }
@@ -210,18 +210,18 @@ $(function () {
               inner = inner.toString();
             }
             if (typeof inner === 'string') {
-              toType = '.toString()';
+              toType = 'v.toString()';
             }
             if (typeof inner === 'number') {
               if (Number.isInteger(inner)) {
-                toType = '.toInt()';
+                toType = 'int.tryParse(v.toString() ?? \'\')';
               } else {
-                toType = '.toDouble()';
+                toType = 'double.tryParse(v.toString() ?? \'\')';
               }
             }
           }
           if ((typeof inner === 'string') || (typeof inner === 'number') || (typeof inner === 'boolean')) {
-            fromJsonLines.push(`${makeBlank(count * 3)}v.forEach((v) {\n${makeBlank(count * 4)}arr${count}.add(v${toType});\n${makeBlank(count * 3)}});`);
+            fromJsonLines.push(`${makeBlank(count * 3)}v.forEach((v) {\n${makeBlank(count * 4)}arr${count}.add(${toType});\n${makeBlank(count * 3)}});`);
             toJsonLines.push(`${makeBlank(count * 3)}v.forEach((v) {\n${makeBlank(count * 4)}arr${count}.add(v);\n${makeBlank(count * 3)}});`);
           }
         }
@@ -329,7 +329,7 @@ $(function () {
               }
             }
             else {
-              let toType = '';
+              let toType = `json[${jsonKey}]`;
               let type = '';
               if (typeof element === 'boolean') {
                 //bool is special
@@ -340,21 +340,21 @@ $(function () {
                   element = element.toString();
                 }
                 if (typeof element === 'string') {
-                  toType = '?.toString()';
+                  toType = `json[${jsonKey}]?.toString()`;
                   type = 'String';
                 }
                 else if (typeof element === 'number') {
                   if (Number.isInteger(element)) {
-                    toType = '?.toInt()';
+                    toType = `  int.tryParse(json[${jsonKey}]?.toString() ?? '')`;
                     type = 'int';
                   } else {
-                    toType = '?.toDouble()';
+                    toType = `  double.tryParse(json[${jsonKey}]?.toString() ?? '')`;
                     type = 'double';
                   }
                 }
               }
               propsLines.push(`  ${type} ${legalKey};\n`);
-              fromJsonLines.push(`    ${legalKey} = json[${jsonKey}]${toType};\n`);
+              fromJsonLines.push(`    ${legalKey} = ${toType};\n`);
               toJsonLines.push(`    data[${jsonKey}] = ${thisData}${legalKey};\n`);
             }
           }

--- a/code.js
+++ b/code.js
@@ -234,7 +234,7 @@ $(function () {
           count--;
         }
 
-        fromJsonLines.unshift(`${makeBlank(count * 2)}if (json[${jsonKey}] != null) {\n${makeBlank(count * 2)}var v = json[${jsonKey}];\n${makeBlank(count * 2)}var arr0 = ${genericStringGenerator(innerClass, total)}();`);
+        fromJsonLines.unshift(`${makeBlank(count * 2)}if (json[${jsonKey}] != null && (json[${jsonKey}] is List)) {\n${makeBlank(count * 2)}var v = json[${jsonKey}];\n${makeBlank(count * 2)}var arr0 = ${genericStringGenerator(innerClass, total)}();`);
         fromJsonLines.push(`${makeBlank(count * 2)}${makeBlank(count)}${legalKey} = arr0;\n    }\n`);
         toJsonLines.unshift(`    if (${legalKey} != null) {\n      var v = ${legalKey};\n      var arr0 = List();`);
         toJsonLines.push(`      data[${jsonKey}] = arr0;\n    }\n`);
@@ -324,7 +324,7 @@ $(function () {
 
                 lines.unshift(objToDart(element, className, key));
                 propsLines.push(`  ${subClassName} ${legalKey};\n`);
-                fromJsonLines.push(`    ${legalKey} = json[${jsonKey}] != null ? ${subClassName}.fromJson(json[${jsonKey}]) : null;\n`);
+                fromJsonLines.push(`    ${legalKey} = (json[${jsonKey}] != null && (json[${jsonKey}] is Map)) ? ${subClassName}.fromJson(json[${jsonKey}]) : null;\n`);
                 toJsonLines.push(`    if (${legalKey} != null) {\n      data[${jsonKey}] = ${thisData}${legalKey}.toJson();\n    }\n`);
               }
             }

--- a/index.html
+++ b/index.html
@@ -57,6 +57,14 @@
                     </div>
                     <div class="divContainer textInputContainer">
                         <div class="divContainer inputTitle">
+                            <p>Fault tolerance:</p>
+                        </div>
+                        <div class="divContainer inputContainer">
+                            <p><input type="checkbox" name="faultToleranceCheckBox" id="faultToleranceCheckBox"> Fault tolerance for JSON with mismatched data types</p>
+                        </div>
+                    </div>
+                    <div class="divContainer textInputContainer">
+                        <div class="divContainer inputTitle">
                             <p>Force String Type:</p>
                         </div>
                         <div class="divContainer inputContainer">


### PR DESCRIPTION
Add `Fault tolerance` option to support the following types of conversions:

- JSON `int` -> Model `int` in string format
- JSON `double` -> Model `double` in string format
- JSON `int` in string format -> Model `int` or safely become null
- JSON `double` in string format -> Model `double` or safely become null
- JSON should be `Map` but any other wrong type in fact -> Model object will safely become null
- JSON should be `List` but any other wrong type in fact -> Model object will safely become null